### PR TITLE
FIx `getUID` example by calling `ds24.begin()`

### DIFF
--- a/examples/DS2401-getUID/DS2401-getUID.ino
+++ b/examples/DS2401-getUID/DS2401-getUID.ino
@@ -23,6 +23,7 @@ void setup()
   Serial.print("DS2401_LIB_VERSION: ");
   Serial.println(DS2401_LIB_VERSION);
 
+  ds24.begin(); // read UID
   Serial.print("\ngetUID:\t ");
   ds24.getUID(uid);
   for (int i = 0; i < 8; i++)

--- a/library.json
+++ b/library.json
@@ -23,7 +23,7 @@
       "version": "^2.3.5"
     }
   ],
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "frameworks": "*",
   "platforms": "*",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=DS2401
-version=0.1.1
+version=0.1.2
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library for 1-Wire DS2401 UID restricted to a single device per pin.


### PR DESCRIPTION
Before calling `ds24.begin()` the example only printed zeros..